### PR TITLE
Cassandra: disable initial host lookup

### DIFF
--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -53,6 +53,7 @@ func (driver *Driver) Initialize(rawurl string) error {
 	cluster.Consistency = gocql.All
 	cluster.Timeout = 1 * time.Minute
 	cluster.ConnectTimeout = 5 * time.Second
+	cluster.DisableInitialHostLookup = true
 
 	if len(u.Query().Get("protocol")) > 0 {
 		protoversion, err := strconv.Atoi(u.Query().Get("protocol"))


### PR DESCRIPTION
Having this causes the first query (to get the current version) to fail on our bigger cross-geography cluster, because it tries to connect to all the nodes first. For a cluster with 15 nodes spread across geographies, it seems to somehow err or take too long frequently, so we get a `Cannot achieve consistency level ALL` error