### PR TITLE
Change Cassandra to use quorum consistency level

### DIFF
--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -50,7 +50,7 @@ func (driver *Driver) Initialize(rawurl string) error {
 
 	cluster := gocql.NewCluster(u.Host)
 	cluster.Keyspace = u.Path[1:len(u.Path)]
-	cluster.Consistency = gocql.All
+	cluster.Consistency = gocql.Quorum
 	cluster.Timeout = 1 * time.Minute
 	cluster.ConnectTimeout = 5 * time.Second
 	cluster.DisableInitialHostLookup = true


### PR DESCRIPTION
This change was motivated by a strange situation: a network partition in a multi-DC cluster, where 2 specific DCs
couldn't talk to each other. This is a workaround while we resolve, enabling us to at least deploy. Schema changes
should still work applied anywhere, but may report a failure if initially run in one of those 2 DCs (I tried this out).